### PR TITLE
[Halo,Red-HD] Fix windowstyle colours for lists

### DIFF
--- a/src/skins/1080/Halo/skin.xml
+++ b/src/skins/1080/Halo/skin.xml
@@ -206,6 +206,7 @@
 		<color name="ListboxBackground" color="menubackground" />
 		<color name="ListboxForeground" color="white" />
 		
+		<color name="ListboxSelectedForeground" color="white" />
 		<color name="ListboxSelectedBackground" color="black" />
 		<color name="ListboxMarkedBackground" color="window-sel-bg" />
 		<color name="ListboxMarkedForeground" color="white" />

--- a/src/skins/720/Red-HD/skin.xml
+++ b/src/skins/720/Red-HD/skin.xml
@@ -85,11 +85,11 @@
 	</colors>
 	<windowstyle type="skinned" id="0">
 		<title offset="35,10" font="vmbold;24" />
-		<color name="Background" color="#002f0e0e" />
+		<color name="Background" color="vmdarkred" />
 		<color name="LabelForeground" color="white" />
-		<color name="ListboxBackground" color="#002f0e0e" />
+		<color name="ListboxBackground" color="vmdarkred" />
 		<color name="ListboxForeground" color="white" />
-		<color name="ListboxSelectedBackground" color="vmdarkred" />
+		<color name="ListboxSelectedBackground" color="vmlightred" />
 		<color name="ListboxSelectedForeground" color="white" />
 		<color name="ListboxMarkedBackground" color="window-sel-bg" />
 		<color name="ListboxMarkedForeground" color="#00a08500" />


### PR DESCRIPTION
In the Halo & Red-HD skins, the SkinSelector skins define a SkinList
widget, which makes them fall back to the embedded skin for
SkinSelector, and use the default Listbox colours in <windowstyle
type="skinned"/>.

The colours are defined poorly in both skins, so that no selection
box appears in the Red-HD SkinSelector screen, and the selection
box obscured the selected entry's text in Halo.

The fix changes the colours so that the selection bar and the text
in the selected entry can be seen.

In Red-HD, the fix also changes instances ofcolor="#002f0e0e" to
the named equivalent "vmdarkred", so that the colouring is clearer.