### PR TITLE
make ColorButtonTemplate adaptive for smaller screens

### DIFF
--- a/src/skins/1080/Simple_Ten_Eighty/skin_templates.xml
+++ b/src/skins/1080/Simple_Ten_Eighty/skin_templates.xml
@@ -108,12 +108,12 @@
 	<screen name="ColorButtonTemplate">
 		<widget addon="ColorButtonsSequence" connection="key_red,key_green,key_yellow,key_blue" 
 			textColors="key_red:buttonred,key_green:buttongreen,key_yellow:buttonyellow,key_blue:buttonblue" 
-			position="224,1030" size="1694,42" font="Regular;33" backgroundColor="darkgrey" transparent="1" alignment="left" zPosition="2" spacing="10" />
+			position="224,e-50" size="e-224,42" font="Regular;33" backgroundColor="darkgrey" transparent="1" alignment="left" zPosition="2" spacing="10" />
 	</screen>
 	<screen name="ActionButtonTemplate">
 		<widget addon="ButtonSequence" connection="key_help,key_info,key_menu,key_play,key_text,VKeyIcon,key_previous,key_left,key_right,key_next,key_0" 
 		pixmaps="key_previous:buttons/key_prev.png,key_left:buttons/left.png,key_help:buttons/key_help.png,key_info:buttons/key_info.png,key_menu:buttons/key_menu.png,key_play:buttons/key_right.png,key_text:buttons/key_text.png,VKeyIcon:buttons/key_text.png,key_0:buttons/key_0.png,key_right:buttons/right.png,key_next:buttons/key_next.png" 
-			position="10,1031" size="212,38" spacing="0" transparent="1" zPosition="10"/>
+			position="10,e-49" size="212,38" spacing="0" transparent="1" zPosition="10"/>
 	</screen>
 	<screen name="ButtonTemplate">
 		<panel name="ColorButtonTemplate"/>


### PR DESCRIPTION
<img width="1920" height="1080" alt="buttons" src="https://github.com/user-attachments/assets/5d09f715-c940-47a5-8184-373944527b24" />

position and size were fixed for 1080 screens. now they use e to adapt to variable sized screens.
