### PR TITLE
make TopTemplate work for smaller than FHD screen sizes

### DIFF
--- a/src/skins/1080/Simple_Ten_Eighty/skin_templates.xml
+++ b/src/skins/1080/Simple_Ten_Eighty/skin_templates.xml
@@ -29,14 +29,14 @@
 	</screen>
 
 	<screen name="TopTemplate">
-		<eLabel position="0,0" size="1920,87" backgroundColor="toptemplatecolor"/>
-		<ePixmap pixmap="border/smallshadowline.png" position="0,87" size="1920,3" zPosition="2"/>
-		<widget source="ScreenPath" conditional="ScreenPath" render="Label" position="30,5" size="1860,35" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;24" valign="center" halign="left"/>
-		<widget source="Title" render="Label" position="30,36" size="1860,45" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;40" valign="center" halign="left"/>
-		<widget source="global.CurrentTime" render="Label" position="1665,5" size="225,40" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;36" valign="center" halign="right">
+		<eLabel position="0,0" size="e,87" backgroundColor="toptemplatecolor"/>
+		<ePixmap pixmap="border/smallshadowline.png" position="0,87" size="e,3" zPosition="2"/>
+		<widget source="ScreenPath" conditional="ScreenPath" render="Label" position="30,5" size="e-30,35" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;24" valign="center" halign="left"/>
+		<widget source="Title" render="Label" position="30,36" size="e-30,45" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;40" valign="center" halign="left"/>
+		<widget source="global.CurrentTime" render="Label" position="e-255,5" size="225,40" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;36" valign="center" halign="right">
 			<convert type="ClockToText">Format:%-H:%M</convert>
 		</widget>
-		<widget source="global.CurrentTime" render="Label" position="1440,45" size="450,37" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;26" valign="center" halign="right">
+		<widget source="global.CurrentTime" render="Label" position="e-480,45" size="450,37" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;26" valign="center" halign="right">
 			<convert type="ClockToText">Date</convert>
 		</widget>
 	</screen>


### PR DESCRIPTION
replace hardcoded 1920 x 1080 screen size with e x e for calculation of screen elements to make it work for all screen sizes.

<img width="1920" height="1080" alt="toptemplate" src="https://github.com/user-attachments/assets/74296392-1ee8-4997-b1e9-0fd536ad4737" />
